### PR TITLE
feat(ui): 모바일 헤더·사이드바 정렬 고정 및 날씨 위젯 슬라이더 안정화

### DIFF
--- a/src/main/resources/static/css/common/header.css
+++ b/src/main/resources/static/css/common/header.css
@@ -1,5 +1,6 @@
 /* 레이아웃 */
 header {
+    min-width: 330px;
     background-color: white;
     height: 60px;
     padding: 0 20px;
@@ -7,6 +8,8 @@ header {
     align-items: center;
     justify-content: space-between;
     box-sizing: border-box;
+    position: sticky;
+    z-index: 1300;
 }
 
 .logo {
@@ -29,6 +32,7 @@ header {
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-shrink: 0;
 }
 
 /* 헤더 안의 버튼만 모양 통일 */
@@ -67,27 +71,22 @@ header .btn-secondary {
 header > .d-flex { min-width: 0; }           /* 왼쪽 영역이 이상하게 밀리지 않도록 */
 .header-right { flex-shrink: 0; }            /* 버튼 영역 과도한 수축 방지 */
 
-/* 2) 390px 이하에서 크기 조정 */
-@media (max-width: 390px) {
-    header {
-        padding: 0 12px;
-        height: 60px;
-    }
-    .logo img {
-        height: 34px;
-        margin-right: 2px;
-    }
-    .logo-text {
-        font-size: 20px;
-        font-weight: 800;
-    }
+/* 매우 좁은 화면 대응 */
+@media (max-width: 405px) {
+    .user-name { display: none; }       /* 유저명 숨김 → 버튼만 남겨 폭 절약 */
+    header .btn { min-width: 64px; }    /* 버튼 최소폭 축소(가독성 유지) */
+}
+
+/* 390px 이하에서 크기 조정 */
+@media (max-width: 550px) {
+    header { padding: 0 10px; height: 60px; }
+    .logo img { height: 30px; }
+    .logo-text { font-size: 18px; font-weight: 800; }
 
     .header-right { gap: 6px; }
-
-    /* 버튼 크기 살짝 축소 */
     header .btn {
         padding: 6px 10px;
-        min-width: 64px;      /* 80 → 64 */
+        min-width: 60px;
         font-size: 12px;
         line-height: 1.2;
     }

--- a/src/main/resources/static/css/common/sidebar.css
+++ b/src/main/resources/static/css/common/sidebar.css
@@ -1,13 +1,14 @@
 .sidebar {
     background-color: #2338a0;
-    min-width: 404px;
+    width: 400px; /* 데스크톱 기준 너비 고정 */
     padding-top: 20px;
-    min-height: calc(100vh - 60px);
+    min-height: calc(100svh - 60px); /* 주소창 변동 안정화 */
     transition: transform 0.3s ease-in-out;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
 }
+
 .sidebar .nav-link {
     color: rgba(255, 255, 255, 0.8);
     font-weight: 500;
@@ -16,15 +17,18 @@
     gap: 10px;
     padding: 10px 20px;
 }
+
 .sidebar .nav-link i {
     color: white;
 }
+
 .sidebar .nav-link:hover,
 .sidebar .nav-link:focus {
     /*background-color: #4da3f9;*/
     background-color: #0b5ed7;
     color: #fff;
 }
+
 .sidebar .nav-link:hover i,
 .sidebar .nav-link:focus i {
     color: #fff;
@@ -39,14 +43,19 @@
 /* 모바일에서 사이드바 토글 형태 */
 @media (max-width: 1370px) {
     .sidebar {
-        position: absolute;
-        top: 60px;
+        position: fixed;                    /* 화면 위에 고정 (본문에 영향 X) */
+        top: 60px;                          /* 헤더 높이만큼 아래 */
         left: 0;
-        width: 180px;
-        height: auto;
-        background-color: #2338a0;
+        width: 78vw;                        /* 기기 폭 기준 */
+        max-width: 400px;
+        min-width: 335px;
+        height: calc(100svh - 60px);        /* 화면 가용 높이 */
         transform: translateX(-100%);
-        z-index: 1000;
+        background-color: #2338a0;
+        z-index: 1200;                      /* 헤더/본문 위로 */
+        overflow-y: auto;                   /* 내부 스크롤 */
+        -webkit-overflow-scrolling: touch;  /* iOS 부드러운 스크롤 */
+        padding-bottom: env(safe-area-inset-bottom, 0); /* iOS 하단 안전영역 */
     }
     .sidebar.show {
         transform: translateX(0);

--- a/src/main/resources/static/css/common/style.css
+++ b/src/main/resources/static/css/common/style.css
@@ -1,9 +1,10 @@
 /* 모든 요소에 NanumSquare 폰트 적용 */
 html, body {
-    min-width: 545px;
+    min-width: 0;
     margin: 0;
-    overflow-x: auto;  /* 더 좁은 기기에서 가로 스크롤로 대응 */
+    overflow-x: hidden;
     font-family: 'NanumSquare', sans-serif;
+    overscroll-behavior-y: contain; /* 당길 때 레이아웃 튐 완화 */
 }
 * {
     font-family: inherit;
@@ -11,11 +12,16 @@ html, body {
 /* 헤더(60px) 제외한 본문 높이를 '보이는 화면'에 정확히 맞춤 */
 .app-body {
     min-height: calc(100svh - 60px);
+    position: relative;
     box-sizing: border-box;
+}
+
+body.sidebar-open {
+    overflow: hidden;
 }
 
 .main-content {
     flex: 1 1 auto;
     min-width: 0;
-    overflow: auto;                      /* 내용 많을 때 본문만 스크롤 */
+    overflow: auto; /* 내용 많을 때 본문만 스크롤 */
 }

--- a/src/main/resources/static/css/common/weather.css
+++ b/src/main/resources/static/css/common/weather.css
@@ -5,8 +5,8 @@
     border-radius: 18px;
     padding: 15px 8px;
     margin: 20px 12px;
-    width: 100%;
-    max-width: 380px;
+    width: calc(100% - 24px); /* 좌우 여백 고려 */
+    max-width: 100%;
     box-sizing: border-box;
 }
 
@@ -19,6 +19,7 @@
     padding: 0 4px;
     gap: 4px;
 }
+
 .current-time-display {
     flex-grow: 1;
     color: #fff;
@@ -40,6 +41,7 @@
     padding: 6px;
     border-radius: 50%;
 }
+
 .weather-prev-btn:hover,
 .weather-next-btn:hover {
     transform: scale(1.3);
@@ -51,14 +53,15 @@
     overflow: hidden;
     width: 100%;
     max-width: 100%;
-    padding: 0 4px;
     box-sizing: border-box;
 }
+
 .weather-card-list {
     display: flex;
-    gap: 12px;
+    gap: 9px;
     transition: transform 0.5s ease-in-out;
 }
+
 .weather-card-item {
     width: 110px;
     flex-shrink: 0;
@@ -77,12 +80,37 @@
     justify-content: center;
     margin: 6px 0;
 }
+
 .weather-icon-temp img {
     width: 70px;
     height: 70px;
 }
+
 .temp-text {
     font-size: 16px;
     font-weight: bold;
-    text-shadow: 1px 1px 2px rgba(0,0,0,.4);
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, .4);
+}
+
+@media (max-width: 430px) {
+    .weather-card-item {
+        width: 86px;
+    }
+
+    .weather-icon-temp img {
+        width: 56px;
+        height: 56px;
+    }
+
+    .temp-text {
+        font-size: 12px;
+    }
+
+    .weather-text {
+        font-size: 10px;
+    }
+
+    .weather-header-row {
+        gap: 2px;
+    }
 }


### PR DESCRIPTION
- header.css
  - 모바일에서 버튼/로고 크기 축소(≤550px), 사용자명 축소/숨김(≤405px)
  - 햄버거 버튼 1370px 이하 노출
  - z-index 정리(헤더 1300)로 오버레이 요소 위에 항상 노출

- sidebar.css
  - 높이: height: calc(100svh - 60px), 내부 스크롤(overflow-y: auto)로 위젯 잘림 방지
  - 폭: width: 78vw (max-width: 400px)로 기기폭 대응
  - 데스크톱에선 고정 폭(400px), 세로 채움(min-height: calc(100svh - 60px))

- weather.css
  - 위젯 폭 유연화: width: calc(100% - 24px), max-width: 100%
  - 작은 화면(≤430px)에서 카드/아이콘/텍스트 축소

- weather.js
  - 슬라이더 재작성: 화면/사이드바 폭 변화 시 매번 실측 → translateX 재계산
    - recalcMetrics(): 카드폭+gap 측정, visibleCards 계산
    - getMaxStartMinusOne(): 원하는 연출을 위해 마지막 페이지 한 칸 덜 가도록(-1) 계산
    - applyTransformAndButtons(): 위치/버튼 상태 동기화
  - 옵저버 추가
    - MutationObserver: 사이드바 열림/닫힘(transitionend) 후 재계산
    - ResizeObserver: .weather-cards-container(및 위젯) 폭 변화 시 재계산
    - window resize / orientationchange 디바운스 적용
  - 시간 표시 로직 정각 동기화
  - 데이터 렌더(renderWeather): 이미지 로딩 완료 후 한 번 더 재계산
  - (문제 해결) 위젯 크기 축소 시 마지막 카드가 안 보이는 현상 보정

- style.css
  - html, body: overflow-x: hidden; min-width 제거로 모바일 가로 스크롤 방지
  - .app-body: min-height: calc(100svh - 60px)