### PR TITLE
[기능 추가] 임야 화재 통계 수집 배치/스케줄러/매퍼 추가 및 JSON 파싱 정리

### DIFF
--- a/src/main/java/com/daepihasan/DaepihasanApplication.java
+++ b/src/main/java/com/daepihasan/DaepihasanApplication.java
@@ -2,8 +2,10 @@ package com.daepihasan;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling // 스케줄러
 public class DaepihasanApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/daepihasan/controller/StatisticsController.java
+++ b/src/main/java/com/daepihasan/controller/StatisticsController.java
@@ -1,0 +1,32 @@
+package com.daepihasan.controller;
+
+import com.daepihasan.service.IFireForestStatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RequestMapping(value = "/stat")
+@RequiredArgsConstructor
+@RestController
+public class StatisticsController {
+
+    // 의존성 주입
+    private final IFireForestStatService fireForestStatService;
+
+    //    1. 임야 화제 통계
+    @GetMapping("/fire-forest/ingest")
+    public String ingest() {
+        log.info("{}.ingest Start!", this.getClass().getName());
+
+        fireForestStatService.ingest();
+
+        log.info("{}.ingest End!", this.getClass().getName());
+        return "OK";
+    }
+
+    //    2. 산불 통계
+}

--- a/src/main/java/com/daepihasan/dto/CodeDTO.java
+++ b/src/main/java/com/daepihasan/dto/CodeDTO.java
@@ -1,0 +1,20 @@
+package com.daepihasan.dto;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodeDTO {
+    private String codeCd;     // CODE.CODE_CD
+    private String pCodeCd;    // CODE.P_CODE_CD (대분류는 null)
+    private String codeNm;     // CODE.CODE_NM
+    private String codeStat;   // 'Y' 사용여부
+    private String regId;
+    private LocalDateTime regDt;
+    private String chgId;
+    private LocalDateTime chgDt;
+}

--- a/src/main/java/com/daepihasan/dto/FireForestStatDTO.java
+++ b/src/main/java/com/daepihasan/dto/FireForestStatDTO.java
@@ -1,0 +1,28 @@
+package com.daepihasan.dto;
+
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FireForestStatDTO {
+    private String wdldSclsfCd;      // 대분류 코드(CODE.CODE_CD)
+    private String wdldSclsfNm;      // 대분류명
+    private LocalDate ocrnYmd;      // 발생년월일
+
+    private long ocrnMnb;           // 발생건수
+    private long lifeDmgPercnt;     // 인명피해인원수
+    private long vctmPercnt;        // 사고자인원수
+    private long injrdprPercnt;     // 부상자인원수
+    private long prptDmgSbttAmt;    // 재산피해소계금액
+
+    private LocalDate searchDate;   // 데이터 수집일자(API 호출일)
+    private String regId;
+    private LocalDateTime regDt;
+    private String chgId;
+    private LocalDateTime chgDt;
+}

--- a/src/main/java/com/daepihasan/mapper/IFireForestMapper.java
+++ b/src/main/java/com/daepihasan/mapper/IFireForestMapper.java
@@ -1,0 +1,26 @@
+package com.daepihasan.mapper;
+
+import com.daepihasan.dto.CodeDTO;
+import com.daepihasan.dto.FireForestStatDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.time.LocalDate;
+
+@Mapper
+public interface IFireForestMapper {
+
+    /** FIRE_FOREST_STAT 비어있으면 null, 있으면 최대 발생일 */
+    LocalDate selectMaxOcrnYmd();
+
+    /** P_CODE_CD='001'(임야) 하위에서 CODE_NM 일치하는 소분류 코드 조회 */
+    CodeDTO getSclsfCodeByName(CodeDTO pDTO);
+
+    /** 임야(001) 하위 6자리 코드 다음 값 채번 (001001, 001002 ...) */
+    String selectNextSclsfCode();
+
+    /** CODE(소분류) 신규 추가 */
+    int insertSclsfCode(CodeDTO pDTO);
+
+    /** FIRE_FOREST_STAT UPSERT(덮어쓰기) - PK: (WDLD_SCLSF_CD, OCRN_YMD) */
+    int upsertFireForestStat(FireForestStatDTO pDTO);
+}

--- a/src/main/java/com/daepihasan/scheduler/FireForestIngestScheduler.java
+++ b/src/main/java/com/daepihasan/scheduler/FireForestIngestScheduler.java
@@ -1,0 +1,31 @@
+package com.daepihasan.scheduler;
+
+import com.daepihasan.service.IFireForestStatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FireForestIngestScheduler {
+
+    private final IFireForestStatService fireForestStatService;
+
+    // 매일 새벽 03:00에 실행
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void runDailyIngest() {
+        log.info("{}.runDailyIngest Start!", this.getClass().getName());
+        try {
+            fireForestStatService.ingest(); // 배치 진입점 호출
+        } catch (Exception e) {
+            log.error("[Scheduler] FireForest ingest failed", e);
+        }
+        log.info("{}.runDailyIngest End!", this.getClass().getName());
+    }
+
+    // 개발 중 빠르게 확인하고 싶으면 주석 해제해서 사용
+    // @Scheduled(initialDelayString = "PT10S", fixedDelayString = "PT1H")
+    // public void debugRun() { fireForestStatService.ingest(); }
+}

--- a/src/main/java/com/daepihasan/service/IFireForestStatService.java
+++ b/src/main/java/com/daepihasan/service/IFireForestStatService.java
@@ -1,0 +1,5 @@
+package com.daepihasan.service;
+
+public interface IFireForestStatService {
+    void ingest(); // 배치 진입점
+}

--- a/src/main/java/com/daepihasan/service/impl/FireForestService.java
+++ b/src/main/java/com/daepihasan/service/impl/FireForestService.java
@@ -1,0 +1,178 @@
+package com.daepihasan.service.impl;
+
+import com.daepihasan.dto.CodeDTO;
+import com.daepihasan.dto.FireForestStatDTO;
+import com.daepihasan.mapper.IFireForestMapper;
+import com.daepihasan.service.IFireForestStatService;
+import com.daepihasan.util.CmmUtil;
+import com.daepihasan.util.NetworkUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URLEncoder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FireForestService implements IFireForestStatService {
+
+    private final IFireForestMapper fireForestMapper;
+
+    @Value("${data.api.decodeKey}")
+    private String apiKey;
+
+    private static final String API_URL =
+            "http://apis.data.go.kr/1661000/FireInformationService/getOcBywdldFpcnd";
+    private static final DateTimeFormatter YMD = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Override
+    @Transactional
+    public void ingest() {
+        log.info("{}.ingest Start!", this.getClass().getName());
+
+        // 구간 결정: 비어있으면 2015-01-01부터, 있으면 MAX+1일부터 어제까지
+        LocalDate maxYmd = fireForestMapper.selectMaxOcrnYmd();
+        log.info("maxYmd: {}", maxYmd);
+
+        LocalDate start  = (maxYmd == null) ? LocalDate.of(2015, 1, 1) : maxYmd.plusDays(1);
+        LocalDate end    = LocalDate.now().minusDays(1);
+
+        log.info("start: {}, end: {}", maxYmd, start, end);
+
+        if (start.isAfter(end)) {
+            log.info("신규 수집 대상 없음: start={}, end={}", start, end);
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            String ocrnYmdStr = d.format(YMD);
+
+            String url = API_URL
+                    + "?serviceKey=" + URLEncoder.encode(apiKey, UTF_8)
+                    + "&pageNo=1&numOfRows=10000&resultType=json"
+                    + "&ocrn_ymd=" + ocrnYmdStr;
+
+            String json = NetworkUtil.get(url);
+
+            try {
+                Map<String, Object> root = mapper.readValue(json, LinkedHashMap.class);
+
+                // body가 최상위인 포멧으로 api 제공
+                Map<String, Object> body = (Map<String, Object>) root.get("body");
+                List<Map<String, Object>> itemList  = (List<Map<String, Object>>) body.get("items");
+
+                log.info("[{}] 수집 {}건", ocrnYmdStr, itemList.size());
+
+                for (Map<String, Object> it : itemList) {
+                    // 소분류명: null/공백 기본값 처리 + 정규화
+                    String rawNm   = String.valueOf(it.get("WDLD_SCLSF_NM"));
+                    String safeNm  = CmmUtil.nvl(rawNm, "기타 임야"); // 소분류 값이 존재하지 않는 경우 기타 임야로 지정
+                    String sclsfNm = normalizeName(safeNm); // 정규화
+
+                    // 코드 조회/생성
+                    String sclsfCd = getOrCreateSclsfCode(sclsfNm);
+
+                    // 숫자값 파싱 (Number/String 모두 허용)
+                    long ocrnMnb = CmmUtil.nvl(String.valueOf(it.get("OCRN_MNB")), 0L);
+                    long life    = CmmUtil.nvl(String.valueOf(it.get("LIFE_DMG_PERCNT")), 0L);
+                    long vctm    = CmmUtil.nvl(String.valueOf(it.get("VCTM_PERCNT")), 0L);
+                    long inj     = CmmUtil.nvl(String.valueOf(it.get("INJRDPR_PERCNT")), 0L);
+                    long prpt    = CmmUtil.nvl(String.valueOf(it.get("PRPT_DMG_SBTT_AMT")), 0L);
+
+                    // 날짜: 하이픈/슬래시 제거 후 yyyyMMdd 보정
+                    String ymd = CmmUtil.nvl(String.valueOf(it.get("OCRN_YMD")), ocrnYmdStr);
+                    LocalDate ocrnYmd = LocalDate.parse(ymd, YMD);
+
+                    LocalDate searchDt  = LocalDate.now();
+                    LocalDateTime nowTs = LocalDateTime.now();
+
+                    FireForestStatDTO dto = FireForestStatDTO.builder()
+                            .wdldSclsfCd(sclsfCd)
+                            .wdldSclsfNm(sclsfNm)
+                            .ocrnYmd(ocrnYmd)
+                            .ocrnMnb(ocrnMnb)
+                            .lifeDmgPercnt(life)
+                            .vctmPercnt(vctm)
+                            .injrdprPercnt(inj)
+                            .prptDmgSbttAmt(prpt)
+                            .searchDate(searchDt)
+                            .regId("SYSTEM")
+                            .regDt(nowTs)
+                            .chgId("SYSTEM")
+                            .chgDt(nowTs)
+                            .build();
+
+                    log.info("FireForestStatDTO.getWdldSclsfCd: {}", dto.getWdldSclsfCd());
+                    log.info("FireForestStatDTO.getWdldSclsfNm: {}", dto.getWdldSclsfNm());
+                    log.info("FireForestStatDTO.getOcrnYmd: {}", dto.getOcrnYmd());
+                    log.info("FireForestStatDTO.getOcrnMnb: {}", dto.getOcrnMnb());
+                    log.info("FireForestStatDTO.getLifeDmgPercnt: {}", dto.getLifeDmgPercnt());
+                    log.info("FireForestStatDTO.getVctmPercnt: {}", dto.getVctmPercnt());
+                    log.info("FireForestStatDTO.getInjrdprPercnt: {}", dto.getInjrdprPercnt());
+                    log.info("FireForestStatDTO.getPrptDmgSbttAmt: {}", dto.getPrptDmgSbttAmt());
+                    log.info("FireForestStatDTO.getSearchDate: {}", dto.getSearchDate());
+
+                    fireForestMapper.upsertFireForestStat(dto);
+                }
+
+            } catch (Exception e) {
+                log.error("[{}] 처리 실패 - 롤백", ocrnYmdStr, e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        log.info("{}.ingest End!", this.getClass().getName());
+    }
+
+
+    /** 이름 정규화: ',-,·' → '.' + 공백 정리 */
+    private String normalizeName(String s) {
+        s = CmmUtil.nvl(s, "기타 들불");
+        s = s.replace('\u00A0', ' ').trim();
+        s = s.replace('·', '.').replace('∙', '.').replace('・', '.').replace('ㆍ', '.');
+        s = s.replace(',', '.').replace('-', '.');
+        s = s.replaceAll("\\s+", " ");
+        if (s.isEmpty()) s = "기타 들불";
+        return s;
+    }
+
+    /** 임야(001) 하위 소분류 코드 조회/생성 */
+    private String getOrCreateSclsfCode(String sclsfNm) {
+        log.info("{}.getOrCreateSclsfCode Start!", this.getClass().getName());
+
+        CodeDTO q = CodeDTO.builder().codeNm(sclsfNm).build();
+        CodeDTO cur = fireForestMapper.getSclsfCodeByName(q);
+        if (cur != null && cur.getCodeCd() != null) {
+            return cur.getCodeCd();
+        }
+        String next = fireForestMapper.selectNextSclsfCode();
+        CodeDTO ins = CodeDTO.builder()
+                .codeCd(next)
+                .codeNm(sclsfNm)
+                .codeStat("Y")
+//                .regId("SYSTEM")
+//                .chgId("SYSTEM")
+                .build();
+        fireForestMapper.insertSclsfCode(ins);
+
+        log.info("CodeDTO.getCodeCd(): {}", ins.getCodeCd());
+        log.info("CodeDTO.getCodeNm(): {}", ins.getCodeNm());
+        log.info("CodeDTO.getCodeStat(): {}", ins.getCodeStat());
+
+        log.info("{}.getOrCreateSclsfCode End!", this.getClass().getName());
+
+        return next;
+    }
+}

--- a/src/main/java/com/daepihasan/util/CmmUtil.java
+++ b/src/main/java/com/daepihasan/util/CmmUtil.java
@@ -2,12 +2,42 @@ package com.daepihasan.util;
 
 // null-safe 처리, HTML input 값 체크(checked, selected)
 public class CmmUtil {
+	public static Long nvl(String str, Long chg_num) {
+		Long res;
+
+		if (str == null) {
+			res = chg_num;
+		} else if (str.equals("")) {
+			res = chg_num;
+		} else {
+			res = Long.valueOf(str);
+		}
+		return res;
+	}
+
+	public static Long nvl(Long num, Long chg_num) {
+		Long res;
+
+		if(num == null) {
+			res = chg_num;
+		} else if(num == 0) {
+			res = chg_num;
+		} else {
+			res = num;
+		}
+		return res;
+	}
+
+	public static Long nvl(Long num) {
+		return nvl(num, 0L);
+	}
+
 	public static Integer nvl(Integer num, Integer chg_num) {
 		Integer res;
 
-		if(num == 0) {
+		if(num == null) {
 			res = chg_num;
-		} else if(num == null) {
+		} else if(num == 0) {
 			res = chg_num;
 		} else {
 			res = num;

--- a/src/main/resources/mapper/FireForestMapper.xml
+++ b/src/main/resources/mapper/FireForestMapper.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- JAVA와 연결할 Mapper 파일 설정 -->
+<mapper namespace="com.daepihasan.mapper.IFireForestMapper">
+
+    <!-- 비었으면 NULL -->
+    <select id="selectMaxOcrnYmd" resultType="java.time.LocalDate">
+        SELECT MAX(OCRN_YMD) FROM FIRE_FOREST_STAT
+    </select>
+
+    <!-- 소분류 코드 조회: 임야(001) 하위에서 CODE_NM 일치 -->
+    <select id="getSclsfCodeByName"
+            parameterType="CodeDTO"
+            resultType="CodeDTO">
+        SELECT
+            CODE_CD   AS codeCd,
+            P_CODE_CD AS pCodeCd,
+            CODE_NM   AS codeNm,
+            CODE_STAT AS codeStat
+        FROM CODE
+        WHERE P_CODE_CD = '001'
+          AND CODE_STAT = 'Y'
+          AND CODE_NM = #{codeNm}
+        LIMIT 1
+    </select>
+
+    <!-- 임야 하위 다음 6자리 코드 생성 -->
+    <select id="selectNextSclsfCode" resultType="string">
+        SELECT CONCAT('001', LPAD(COALESCE(MAX(CAST(SUBSTRING(CODE_CD,4,3) AS UNSIGNED)), 0) + 1, 3, '0'))
+        FROM CODE
+        WHERE P_CODE_CD = '001'
+          AND CHAR_LENGTH(CODE_CD) = 6
+    </select>
+
+    <!-- CODE(소분류) 신규 추가 -->
+    <insert id="insertSclsfCode" parameterType="CodeDTO">
+        INSERT INTO CODE (
+            CODE_CD, CODE_NM, P_CODE_CD, CODE_STAT, REG_ID, REG_DT, CHG_ID, CHG_DT
+        ) VALUES (
+                     #{codeCd}, #{codeNm}, '001', 'Y', #{regId}, NOW(), #{chgId}, NOW()
+                 )
+    </insert>
+
+    <!-- FIRE_FOREST_STAT UPSERT (덮어쓰기) -->
+    <insert id="upsertFireForestStat" parameterType="FireForestStatDTO">
+        INSERT INTO FIRE_FOREST_STAT (
+            WDLD_SCLSF_CD, OCRN_YMD,
+            OCRN_MNB, LIFE_DMG_PERCNT, VCTM_PERCNT, INJRDPR_PERCNT, PRPT_DMG_SBTT_AMT,
+            SEARCH_DATE, REG_ID, REG_DT, CHG_ID, CHG_DT
+        ) VALUES (
+                     #{wdldSclsfCd}, #{ocrnYmd},
+                     #{ocrnMnb}, #{lifeDmgPercnt}, #{vctmPercnt}, #{injrdprPercnt}, #{prptDmgSbttAmt},
+                     #{searchDate}, #{regId}, #{regDt}, #{chgId}, #{chgDt}
+                 )
+        ON DUPLICATE KEY UPDATE
+                             -- PK는 갱신 X
+                             OCRN_MNB          = VALUES(OCRN_MNB),
+                             LIFE_DMG_PERCNT   = VALUES(LIFE_DMG_PERCNT),
+                             VCTM_PERCNT       = VALUES(VCTM_PERCNT),
+                             INJRDPR_PERCNT    = VALUES(INJRDPR_PERCNT),
+                             PRPT_DMG_SBTT_AMT = VALUES(PRPT_DMG_SBTT_AMT),
+                             SEARCH_DATE       = VALUES(SEARCH_DATE),
+                             CHG_ID            = VALUES(CHG_ID),
+                             CHG_DT            = VALUES(CHG_DT)
+    </insert>
+
+</mapper>


### PR DESCRIPTION
### PR 타입
- 기능 추가

### 반영 브랜치
feat/34-statistic -> develop

### 반영 사항
- 배치 진입점 인터페이스 추가
  - IFireForestStatService.ingest()를 배치 실행의 단일 진입점으로 정의

- 수동 트리거용 컨트롤러 추가
  - GET /stat/fire-forest/ingest → ingest() 호출

- 스케줄러 도입
  - FireForestIngestScheduler: 매일 03:00 자동 실행
  - DaepihasanApplication에 @EnableScheduling 추가로 스케줄링 활성화

- 서비스 구현
  - FireForestService.ingest():
    - 수집 구간: DB 최대일자(selectMaxOcrnYmd) + 1일 ~ 어제
    - 공공데이터 API 호출: FireInformationService/getOcBywdldFpcnd
    - ObjectMapper + Map으로 응답 파싱(예시 포맷에 맞춰 최상위 body.items 배열 처리)
    - CmmUtil.nvl로 null/공백 기본값 처리(문자/숫자)
    - 명칭 정규화(normalizeName): 특수문자(·∙・ㆍ, 콤마, 하이픈) 정리 및 공백 정리
    - 소분류 코드 조회/미존재 시 생성(getOrCreateSclsfCode)
    - FIRE_FOREST_STAT에 UPSERT(UPDATE, INSERT) 저장

- DTO
  - CodeDTO, FireForestStatDTO 정의

- FireForestMapper 작성
  - selectMaxOcrnYmd: 가장 최신 수집일(LocalDate) 조회
  - getSclsfCodeByName: 임야(001) 하위에서 CODE_NM 일치, Y 상태만
  - selectNextSclsfCode: ‘001’ + 3자리 증가분으로 차기 코드 생성
  - insertSclsfCode: CODE 테이블 신규 행 추가(부모코드 001)
  - upsertFireForestStat: FIRE_FOREST_STAT에 INSERT ~ ON DUPLICATE KEY UPDATE
    - 중복 키 충돌하는 경우 발생하게 되면 건수/피해/수정자/수정일 등 갱신할 수 있도록 함


### 적용 화면
<img width="819" height="410" alt="image" src="https://github.com/user-attachments/assets/fc136d66-92fd-4127-992f-2e4db4db3370" />
