### PR TITLE
[기능 추가] 산불 통계 KPI 조회 기능 추가 및 코드 정리

### DIFF
--- a/src/main/java/com/daepihasan/controller/StatisticsController.java
+++ b/src/main/java/com/daepihasan/controller/StatisticsController.java
@@ -1,11 +1,15 @@
 package com.daepihasan.controller;
 
-import com.daepihasan.service.IFireForestStatService;
+import com.daepihasan.dto.FireForestKpiDTO;
+import com.daepihasan.service.IFireForestService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 
 @Slf4j
@@ -15,18 +19,35 @@ import org.springframework.web.bind.annotation.RestController;
 public class StatisticsController {
 
     // 의존성 주입
-    private final IFireForestStatService fireForestStatService;
+    private final IFireForestService fireForestService;
 
-    //    1. 임야 화제 통계
+    // 1. 임야 화제 통계
     @GetMapping("/fire-forest/ingest")
     public String ingest() {
         log.info("{}.ingest Start!", this.getClass().getName());
 
-        fireForestStatService.ingest();
+        fireForestService.ingest();
 
         log.info("{}.ingest End!", this.getClass().getName());
         return "OK";
     }
 
-    //    2. 산불 통계
+    // 2. 산불 통계
+    /**
+     *  2.1. KPI 조회(현재 지정한 기간과 전동기 통계자료 비교
+     */
+    @PostMapping("/fire-forest/kpi")
+    public FireForestKpiDTO getFireForestKpi() {
+        log.info("{}.getFireForestKpi Start!,", this.getClass().getName());
+
+        FireForestKpiDTO kpi = fireForestService.getKpiYoY(
+                LocalDate.of(2025,1,1),
+                LocalDate.of(2025,12,31)
+        );
+
+        log.info(kpi.toString());
+
+        log.info("{}.getFireForestKpi End!,", this.getClass().getName());
+        return kpi;
+    }
 }

--- a/src/main/java/com/daepihasan/dto/CodeDTO.java
+++ b/src/main/java/com/daepihasan/dto/CodeDTO.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Builder
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class CodeDTO {

--- a/src/main/java/com/daepihasan/dto/FireForestKpiDTO.java
+++ b/src/main/java/com/daepihasan/dto/FireForestKpiDTO.java
@@ -1,0 +1,35 @@
+package com.daepihasan.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class FireForestKpiDTO {
+    // 발생건수
+    private Long cntPrev;     // 전동기 발생건수
+    private Long cntCur;      // 현재 발생건수
+    private Long cntDiff;     // 증감(건수)
+    private Integer cntDiffPct; // 증감률(%)
+
+    // 재산피해
+    private Long propPrev;    // 전동기 재산피해
+    private Long propCur;     // 현재 재산피해
+    private Long propDiff;    // 증감(금액)
+    private Integer propDiffPct; // 증감률(%)
+
+    // 사망
+    private Long deathPrev;   // 전동기 사망자수
+    private Long deathCur;    // 현재 사망자수
+    private Long deathDiff;   // 증감(인)
+    private Integer deathDiffPct; // 증감률(%)
+
+    // 부상
+    private Long injuryPrev;  // 전동기 부상자수
+    private Long injuryCur;   // 현재 부상자수
+    private Long injuryDiff;  // 증감(인)
+    private Integer injuryDiffPct; // 증감률(%)
+}

--- a/src/main/java/com/daepihasan/mapper/ICodeMapper.java
+++ b/src/main/java/com/daepihasan/mapper/ICodeMapper.java
@@ -1,0 +1,17 @@
+package com.daepihasan.mapper;
+
+import com.daepihasan.dto.CodeDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ICodeMapper {
+
+    /** P_CODE_CD='001'(임야) 하위에서 CODE_NM 일치하는 소분류 코드 조회 */
+    CodeDTO getSclsfCodeByName(CodeDTO pDTO);
+
+    /** 임야(001) 하위 6자리 코드 다음 값 채번 (001001, 001002 ...) */
+    String selectNextSclsfCode();
+
+    /** CODE(소분류) 신규 추가 */
+    int insertSclsfCode(CodeDTO pDTO);
+}

--- a/src/main/java/com/daepihasan/mapper/IFireForestMapper.java
+++ b/src/main/java/com/daepihasan/mapper/IFireForestMapper.java
@@ -1,8 +1,9 @@
 package com.daepihasan.mapper;
 
-import com.daepihasan.dto.CodeDTO;
+import com.daepihasan.dto.FireForestKpiDTO;
 import com.daepihasan.dto.FireForestStatDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.time.LocalDate;
 
@@ -12,15 +13,10 @@ public interface IFireForestMapper {
     /** FIRE_FOREST_STAT 비어있으면 null, 있으면 최대 발생일 */
     LocalDate selectMaxOcrnYmd();
 
-    /** P_CODE_CD='001'(임야) 하위에서 CODE_NM 일치하는 소분류 코드 조회 */
-    CodeDTO getSclsfCodeByName(CodeDTO pDTO);
-
-    /** 임야(001) 하위 6자리 코드 다음 값 채번 (001001, 001002 ...) */
-    String selectNextSclsfCode();
-
-    /** CODE(소분류) 신규 추가 */
-    int insertSclsfCode(CodeDTO pDTO);
-
     /** FIRE_FOREST_STAT UPSERT(덮어쓰기) - PK: (WDLD_SCLSF_CD, OCRN_YMD) */
     int upsertFireForestStat(FireForestStatDTO pDTO);
+
+    /** KPI: 현재 구간 vs 전년 동기 */
+    FireForestKpiDTO selectKpiYoY(@Param("from") LocalDate from,
+                                  @Param("to")   LocalDate to);
 }

--- a/src/main/java/com/daepihasan/scheduler/FireForestIngestScheduler.java
+++ b/src/main/java/com/daepihasan/scheduler/FireForestIngestScheduler.java
@@ -1,6 +1,6 @@
 package com.daepihasan.scheduler;
 
-import com.daepihasan.service.IFireForestStatService;
+import com.daepihasan.service.IFireForestService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FireForestIngestScheduler {
 
-    private final IFireForestStatService fireForestStatService;
+    private final IFireForestService fireForestStatService;
 
     // 매일 새벽 03:00에 실행
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")

--- a/src/main/java/com/daepihasan/service/IFireForestService.java
+++ b/src/main/java/com/daepihasan/service/IFireForestService.java
@@ -1,0 +1,12 @@
+package com.daepihasan.service;
+
+import com.daepihasan.dto.FireForestKpiDTO;
+
+import java.time.LocalDate;
+
+public interface IFireForestService {
+    void ingest(); // 배치 진입점
+
+    // KPI: 현재 구간 vs 전년 동기
+    FireForestKpiDTO getKpiYoY(LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/daepihasan/service/IFireForestStatService.java
+++ b/src/main/java/com/daepihasan/service/IFireForestStatService.java
@@ -1,5 +1,0 @@
-package com.daepihasan.service;
-
-public interface IFireForestStatService {
-    void ingest(); // 배치 진입점
-}

--- a/src/main/resources/mapper/CodeMapper.xml
+++ b/src/main/resources/mapper/CodeMapper.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- JAVA와 연결할 Mapper 파일 설정 -->
+<mapper namespace="com.daepihasan.mapper.ICodeMapper">
+
+    <!-- 소분류 코드 조회: 임야(001) 하위에서 CODE_NM 일치 -->
+    <select id="getSclsfCodeByName" parameterType="CodeDTO" resultType="CodeDTO">
+        SELECT
+            CODE_CD, P_CODE_CD, CODE_NM, CODE_STAT
+        FROM CODE
+        WHERE P_CODE_CD = '001'
+          AND CODE_STAT = 'Y'
+          AND CODE_NM = #{codeNm}
+            LIMIT 1
+    </select>
+
+    <!-- 임야 하위 다음 6자리 코드 생성 -->
+    <select id="selectNextSclsfCode" resultType="string">
+        SELECT CONCAT('001', LPAD(COALESCE(MAX(CAST(SUBSTRING(CODE_CD,4,3) AS UNSIGNED)), 0) + 1, 3, '0'))
+        FROM CODE
+        WHERE P_CODE_CD = '001'
+          AND CHAR_LENGTH(CODE_CD) = 6
+    </select>
+
+    <!-- CODE(소분류) 신규 추가 -->
+    <insert id="insertSclsfCode" parameterType="CodeDTO">
+        INSERT INTO CODE (
+            CODE_CD, CODE_NM, P_CODE_CD, CODE_STAT, REG_ID, REG_DT, CHG_ID, CHG_DT
+        ) VALUES (
+                     #{codeCd}, #{codeNm}, '001', 'Y', #{regId}, NOW(), #{chgId}, NOW()
+        )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/FireForestMapper.xml
+++ b/src/main/resources/mapper/FireForestMapper.xml
@@ -65,4 +65,67 @@
                              CHG_DT            = VALUES(CHG_DT)
     </insert>
 
+    <!-- 통계 데이터 조회용 쿼리  -->
+    <!-- KPI: 현재 구간 vs 전년 동기 비교 -->
+    <select id="selectKpiYoY" resultType="com.daepihasan.dto.FireForestKpiDTO">
+        WITH
+            PARAMS AS (
+                SELECT CAST(#{from} AS DATE) AS FROM_DT,
+                       CAST(#{to}   AS DATE) AS TO_DT
+            ),
+            PREV_RNG AS (  -- 전년 동기
+                SELECT DATE_SUB(FROM_DT, INTERVAL 1 YEAR) AS PREV_FROM,
+                       DATE_SUB(TO_DT,   INTERVAL 1 YEAR) AS PREV_TO
+                FROM PARAMS
+            ),
+            CUR AS (  -- 현재 구간 집계
+                SELECT
+                    SUM(OCRN_MNB)          AS CUR_CNT,   -- 현재: 발생건수
+                    SUM(PRPT_DMG_SBTT_AMT) AS CUR_PROP,  -- 현재: 재산피해
+                    SUM(VCTM_PERCNT)       AS CUR_DEATH, -- 현재: 사망자수
+                    SUM(INJRDPR_PERCNT)    AS CUR_INJURY -- 현재: 부상자수
+                FROM FIRE_FOREST_STAT F
+                         JOIN PARAMS P
+                              ON F.OCRN_YMD BETWEEN P.FROM_DT AND P.TO_DT
+            ),
+            PREV AS (  -- 전동기(전년 동기) 구간 집계
+                SELECT
+                    SUM(OCRN_MNB)          AS PREV_CNT,   -- 전동기: 발생건수
+                    SUM(PRPT_DMG_SBTT_AMT) AS PREV_PROP,  -- 전동기: 재산피해
+                    SUM(VCTM_PERCNT)       AS PREV_DEATH, -- 전동기: 사망자수
+                    SUM(INJRDPR_PERCNT)    AS PREV_INJURY -- 전동기: 부상자수
+                FROM FIRE_FOREST_STAT F
+                         JOIN PREV_RNG PR
+                              ON F.OCRN_YMD BETWEEN PR.PREV_FROM AND PR.PREV_TO
+            )
+        SELECT
+            -- ===== 발생건수 =====
+            PREV.PREV_CNT  AS cnt_prev,    -- 전동기 발생건수
+            CUR.CUR_CNT    AS cnt_cur,     -- 현재 발생건수
+            (CUR.CUR_CNT - PREV.PREV_CNT) AS cnt_diff,      -- 발생건수 증감
+            CASE WHEN PREV.PREV_CNT=0 THEN NULL
+                 ELSE ROUND((CUR.CUR_CNT - PREV.PREV_CNT)/PREV.PREV_CNT*100,0) END AS cnt_diff_pct, -- 발생건수 증감률(%)
+
+            -- ===== 재산피해 =====
+            PREV.PREV_PROP AS prop_prev,   -- 전동기 재산피해액
+            CUR.CUR_PROP   AS prop_cur,    -- 현재 재산피해액
+            (CUR.CUR_PROP - PREV.PREV_PROP) AS prop_diff,   -- 재산피해 증감
+            CASE WHEN PREV.PREV_PROP=0 THEN NULL
+                 ELSE ROUND((CUR.CUR_PROP - PREV.PREV_PROP)/PREV.PREV_PROP*100,0) END AS prop_diff_pct, -- 재산피해 증감률(%)
+
+            -- ===== 사망 =====
+            PREV.PREV_DEATH AS death_prev, -- 전동기 사망자수
+            CUR.CUR_DEATH   AS death_cur,  -- 현재 사망자수
+            (CUR.CUR_DEATH - PREV.PREV_DEATH) AS death_diff, -- 사망자 증감
+            CASE WHEN PREV.PREV_DEATH=0 THEN NULL
+                 ELSE ROUND((CUR.CUR_DEATH - PREV.PREV_DEATH)/PREV.PREV_DEATH*100,0) END AS death_diff_pct, -- 사망자 증감률(%)
+
+            -- ===== 부상 =====
+            PREV.PREV_INJURY AS injury_prev, -- 전동기 부상자수
+            CUR.CUR_INJURY   AS injury_cur,  -- 현재 부상자수
+            (CUR.CUR_INJURY - PREV.PREV_INJURY) AS injury_diff, -- 부상자 증감
+            CASE WHEN PREV.PREV_INJURY=0 THEN NULL
+                 ELSE ROUND((CUR.CUR_INJURY - PREV.PREV_INJURY)/PREV.PREV_INJURY*100,0) END AS injury_diff_pct -- 부상자 증감률(%)
+        FROM CUR, PREV
+    </select>
 </mapper>


### PR DESCRIPTION
### PR 타입
- 기능 추가

### 반영 브랜치
feat/34-statistic -> develop

### 반영 사항
- FireForestKpiDTO 신설
  - 발생건수, 재산피해, 사망, 부상 전년동기 대비 지표 포함
- IFireForestMapper
  - selectKpiYoY 쿼리 추가 (현재 기간 vs 전년동기 집계 비교)
- IFireForestMapper
  - selectKpiYoY 메서드 정의
- FireForestService
  - getKpiYoY 서비스 메서드 구현
  - @Transactional(readOnly = true) 적용 (조회 전용 최적화)
  - null 결과시 0/NULL 기본값 채워 반환
- StatisticsController
  - /stat/fire-forest/kpi API 추가 (POST)
- CodeMapper 관련 interface 반환 타입 정리 (String → DTO)